### PR TITLE
Fix problem

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -75,8 +75,6 @@ jobs:
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
-      - name: Static HTML export with Next.js
-        run: ${{ steps.detect-package-manager.outputs.runner }} next export
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Since you didn't pay attention to the error, you missed the documentation that explitly tells you that next export was remove and that the configuration file with export already does the static page export.
https://nextjs.org/docs/advanced-features/static-html-export
![image](https://github.com/Jaykler/Cards-View/assets/74797568/27517b0e-f0a6-46e6-b5c2-4ec002817029)

